### PR TITLE
WIP on Macos support

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,14 +127,14 @@ CUDA_VISIBLE_DEVICES=0 python test.py --name HERO_MODEL \
 for visualizing with rerun use the following command
 ```
 CUDA_VISIBLE_DEVICES=0 python rerun_visualize_live_meshing.py \
-            --name HERO_MODEL
-            --output_base_path OUTPUT_PATH
-            --config_file configs/models/hero_model.yaml
-            --load_weights_from_checkpoint weights/hero_model.ckpt
-            --data_config configs/data/vdr_dense.yaml
-            --num_workers 8
-            --run_fusion
-            --depth_fuser open3d
+            --name HERO_MODEL \
+            --output_base_path OUTPUT_PATH \
+            --config_file configs/models/hero_model.yaml \
+            --load_weights_from_checkpoint weights/hero_model.ckpt \
+            --data_config configs/data/vdr_dense.yaml \
+            --num_workers 8 \
+            --run_fusion \
+            --depth_fuser open3d \
             --fuse_color;
 ```
 This will output meshes, quick depth viz, and socres when benchmarked against LiDAR depth under `OUTPUT_PATH`. 

--- a/simplerecon_env_macos.yml
+++ b/simplerecon_env_macos.yml
@@ -14,6 +14,7 @@ dependencies:
   - pip
   - numpy>=1.23
   - pip:
+    - accelerate # abstraction over cuda/cpu/tpu
     - kornia==0.6.7 # gradients
     - antialiased-cnns # anti aliased resnet
     - efficientnet_pytorch

--- a/simplerecon_env_macos.yml
+++ b/simplerecon_env_macos.yml
@@ -1,0 +1,30 @@
+name: simplerecon
+channels:
+  - default
+  - pytorch
+  - conda-forge
+dependencies:
+  - python=3.9.7
+  - pytorch
+  - torchvision
+  - pytorch-lightning=1.5.4 # training utils
+  - pillow # image op
+  - tensorboard # logging
+  - matplotlib # plotting
+  - pip
+  - numpy>=1.23
+  - pip:
+    - kornia==0.6.7 # gradients
+    - antialiased-cnns # anti aliased resnet
+    - efficientnet_pytorch
+    - timm # efficent
+    - trimesh # mesh loading/storage, and mesh generation
+    - transforms3d # for NeuralRecon's arkit
+    - einops # batching one liners
+    - moviepy # storing videos
+    - pyrender # rendering meshes
+    - open3d==0.14.1 # mesh fusion
+    - scipy # transformations and a few others
+    - setuptools==59.5.0 # fix for tensorboard
+    - https://github.com/alsuren/scikit-image/archive/single_mesh.zip # single mesh exporting for measure.marching_cubes
+    - rerun-sdk==0.5.1 # for visualizing using rerun

--- a/test.py
+++ b/test.py
@@ -124,7 +124,7 @@ from experiment_modules.depth_model import DepthModel
 import options
 from tools import fusers_helper
 from utils.dataset_utils import get_dataset
-from utils.generic_utils import to_gpu, cache_model_outputs
+from utils.generic_utils import to_gpu, cache_model_outputs, device
 from utils.metrics_utils import ResultsAverager, compute_depth_metrics_batched
 from utils.visualization_utils import quick_viz_export
 
@@ -202,10 +202,7 @@ def main(opts):
             isinstance(model.cost_volume, cost_volume.FeatureVolumeManager)):
         model.cost_volume = model.cost_volume.to_fast()
 
-    if platform.system() == "Darwin":
-        model = model.eval()
-    else:
-        model = model.cuda().eval()
+    model = model.to(device).eval()
 
     # setting up overall result averagers
     all_frame_metrics = None

--- a/utils/generic_utils.py
+++ b/utils/generic_utils.py
@@ -3,6 +3,7 @@ import os
 import pickle
 from pathlib import Path
 
+from accelerate import Accelerator
 import kornia
 import torch
 import torchvision.transforms.functional as TF
@@ -10,6 +11,9 @@ from PIL import Image
 from torch import nn
 
 logger = logging.getLogger(__name__)
+
+accelerator = Accelerator()
+device = accelerator.device
 
 
 def copy_code_state(path):
@@ -141,7 +145,7 @@ def to_gpu(input_dict, key_ignores=[]):
     """
     for k, v in input_dict.items():
         if k not in key_ignores:
-            input_dict[k] = v.cuda().float()
+            input_dict[k] = v.to(device).float()
     return input_dict
 
 def imagenet_normalize(image):


### PR DESCRIPTION
Sorry for making this PR against your fork rather than upstream. I happened to start based on your fork, and I really want to get rerun working with simplerecon, so I don't fancy doing it all on upstream without being able to test it. Once I have something working then I will cherry-pick the reusable bits and get them upstreamed. For now, I just want somewhere public to share my progress.

Please ignore or cherry-pick as you prefer.

- [x] I managed to get the first invocation in README working (the test.py one) with a bit of hackery
- [ ] rerun_visualize_live_meshing.py is blocked on https://github.com/pytorch/pytorch/issues/77818 
- [ ] visualize_live_meshing.py is bailing out with `ImportError: ('Unable to load EGL library', ...)`. Probably something to do with `os.environ["PYOPENGL_PLATFORM"] = "egl"` in tools/mesh_renderer.py? I'm not sure how I'm supposed to set this up for macos though. I'll have to keep digging.
- [ ] ... I haven't even looked at any of the other examples
